### PR TITLE
Add support for the new Request::getContentTypeFormat method of Symfony 6.2

### DIFF
--- a/Symfony/Component/HttpFoundation/.phpstorm.meta.php
+++ b/Symfony/Component/HttpFoundation/.phpstorm.meta.php
@@ -72,6 +72,7 @@ namespace PHPSTORM_META {
     expectedReturnValues(\Symfony\Component\HttpFoundation\Request::getFormat(), argumentsSet('symfony_request_formats'));
     expectedReturnValues(\Symfony\Component\HttpFoundation\Request::getRequestFormat(), argumentsSet('symfony_request_formats'));
     expectedReturnValues(\Symfony\Component\HttpFoundation\Request::getContentType(), argumentsSet('symfony_request_formats'));
+    expectedReturnValues(\Symfony\Component\HttpFoundation\Request::getContentTypeFormat(), argumentsSet('symfony_request_formats'));
 
     registerArgumentsSet('symfony_request_mimes',
         'text/html',


### PR DESCRIPTION
This is the new name of the `getContentType` method (which is deprecated)