### PR TITLE
feature: add `HttpKernelInterface::MAIN_REQUEST` reference

### DIFF
--- a/Symfony/Component/HttpKernel/.phpstorm.meta.php
+++ b/Symfony/Component/HttpKernel/.phpstorm.meta.php
@@ -3,6 +3,7 @@
 namespace PHPSTORM_META {
 	registerArgumentsSet('symfony_http_kernel_requests',
 		\Symfony\Component\HttpKernel\HttpKernelInterface::MASTER_REQUEST,
+		\Symfony\Component\HttpKernel\HttpKernelInterface::MAIN_REQUEST,
 		\Symfony\Component\HttpKernel\HttpKernelInterface::SUB_REQUEST
 	);
 


### PR DESCRIPTION
## Description
`HttpKernelInterface::MAIN_REQUEST` constant was introduced in 5.3 and is the replacement of `HttpKernelInterface::MASTER_REQUEST`.

https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpKernel/HttpKernelInterface.php#L27-L31